### PR TITLE
Fix tacotranslate.ts

### DIFF
--- a/examples/nextjs-with-app-router/utilities/tacotranslate.ts
+++ b/examples/nextjs-with-app-router/utilities/tacotranslate.ts
@@ -8,7 +8,8 @@ const tacoTranslate = createTacoTranslateClient({
 	apiKey:
 		process.env.TACOTRANSLATE_SECRET_API_KEY ??
 		process.env.TACOTRANSLATE_PUBLIC_API_KEY ??
-		process.env.TACOTRANSLATE_API_KEY,
+		process.env.TACOTRANSLATE_API_KEY ??
+		"",
 	projectLocale:
 		process.env.TACOTRANSLATE_IS_PRODUCTION === 'true'
 			? defaultLocale


### PR DESCRIPTION
reason:
API key being potentially undefined.

desc:
Now Provided a default value of an empty string ("") for the apiKey variable if none of the environment variables are defined.